### PR TITLE
V4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![RingBufferPlus Logo](https://raw.githubusercontent.com/FRACerqueira/RingBufferPlus/refs/heads/main/docs/images/icon.png) Welcome to RingBufferPlus
+# ![RingBufferPlus Logo](https://raw.githubusercontent.com/FRACerqueira/RingBufferPlus/refs/heads/main/icon.png) Welcome to RingBufferPlus
 
 ## **The generic ring buffer with auto-scaler (elastic buffer).** 
 

--- a/src/RingBufferPlus.Tests/RingBufferManager.cs
+++ b/src/RingBufferPlus.Tests/RingBufferManager.cs
@@ -83,7 +83,7 @@ namespace RingBufferPlus.Tests
             // Arrange
             var builder = new RingBufferBuilder<int>("TestBuffer",null);
             builder.Capacity(5);
-            builder.LockAcquireWhenAutoScale();
+            builder.LockWhenScaling();
             builder.MaxCapacity(10);
             builder.MinCapacity(2);
             builder.Factory((_) => Task.FromResult(0));
@@ -104,7 +104,7 @@ namespace RingBufferPlus.Tests
             // Arrange
             var builder = new RingBufferBuilder<int>("TestBuffer", null);
             builder.Capacity(5);
-            builder.LockAcquireWhenAutoScale();
+            builder.LockWhenScaling();
             builder.MaxCapacity(10);
             builder.MinCapacity(2);
             builder.Factory((_) => Task.FromResult(0));
@@ -124,7 +124,7 @@ namespace RingBufferPlus.Tests
             // Arrange
             var builder = new RingBufferBuilder<int>("TestBuffer", null);
             builder.Capacity(5);
-            builder.LockAcquireWhenAutoScale();
+            builder.LockWhenScaling();
             builder.MaxCapacity(10);
             builder.MinCapacity(2);
             builder.Factory((_) => Task.FromResult(0));

--- a/src/RingBufferPlus/Commands/IRingBufferScaleCapacity.cs
+++ b/src/RingBufferPlus/Commands/IRingBufferScaleCapacity.cs
@@ -32,11 +32,11 @@ namespace RingBufferPlus
         IRingBufferScaleCapacity<T> MaxCapacity(int value);
 
         /// <summary>
-        /// Sets acquisition lock when running auto scale.
+        /// Sets acquisition/Switch lock when running scaleUp/ScaleDown.
         /// </summary>
         /// <param name="value">True to acquisition lock.Default true</param>
         /// <returns></returns>
-        IRingBufferScaleCapacity<T> LockAcquireWhenAutoScale(bool value = true);
+        IRingBufferScaleCapacity<T> LockWhenScaling(bool value = true);
 
         /// <summary>
         /// Sets the condition to autoscale (scale up) capacity when an acquire fault occurs. The Manually change scale will always return false if autoscale is enabled.

--- a/src/RingBufferPlus/Core/RingBufferBuilder.cs
+++ b/src/RingBufferPlus/Core/RingBufferBuilder.cs
@@ -120,7 +120,7 @@ namespace RingBufferPlus.Core
             return this;
         }
 
-        public IRingBufferScaleCapacity<T> LockAcquireWhenAutoScale(bool value = true)
+        public IRingBufferScaleCapacity<T> LockWhenScaling(bool value = true)
         {
             _lockAcquire = value;
             return this;

--- a/src/RingBufferPlus/RingBufferPlus.csproj
+++ b/src/RingBufferPlus/RingBufferPlus.csproj
@@ -8,10 +8,10 @@
 
 	<PropertyGroup>
 		<Authors>Fernando Cerqueira</Authors>
-		<Description>A generic circular buffer (ring buffer) in C# with auto-scaler.</Description>
+		<Description>he generic ring buffer with auto-scaler (elastic buffer).</Description>
 		<PackageReleaseNotes>https://github.com/FRACerqueira/RingBufferPlus/releases</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageTags>csharp;dotnet;dotnetcore;ringbuffer;ring-buffer;circular-buffer;rabittmq;cyclic-buffer</PackageTags>
+		<PackageTags>csharp;dotnet;dotnetcore;ringbuffer;ring-buffer;circular-buffer;rabittmq;cyclic-buffer;elastic-buffer</PackageTags>
 		<RepositoryUrl>https://github.com/FRACerqueira/RingBufferPlus</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageId>RingBufferPlus</PackageId>

--- a/src/docs/assemblies/RingBufferPlus/IRingBuffer-1.md
+++ b/src/docs/assemblies/RingBufferPlus/IRingBuffer-1.md
@@ -20,7 +20,7 @@ public interface IRingBuffer<T> : IRingBufferBuild<T>
 | --- | --- |
 | [AcquireTimeout](IRingBuffer-1/AcquireTimeout.md)(…) | Sets the timeout to acquire buffer. |
 | [BackgroundLogger](IRingBuffer-1/BackgroundLogger.md)(…) | Sets to write in background (evaluation asynchronously). |
-| [Capacity](IRingBuffer-1/Capacity.md)(…) | Sets the initial/startup capacity of the ring buffer. |
+| [Capacity](IRingBuffer-1/Capacity.md)(…) | Sets the initial/startup (required) capacity of the ring buffer. |
 | [Factory](IRingBuffer-1/Factory.md)(…) | Sets the factory (required) to create an instance in the ring buffer asynchronously. |
 | [HeartBeat](IRingBuffer-1/HeartBeat.md)(…) | Sets the HeartBeat in the ring buffer. |
 | [Logger](IRingBuffer-1/Logger.md)(…) | Sets the logger. |

--- a/src/docs/assemblies/RingBufferPlus/IRingBuffer-1/Capacity.md
+++ b/src/docs/assemblies/RingBufferPlus/IRingBuffer-1/Capacity.md
@@ -4,7 +4,7 @@
 </br>
 
 
-#### Sets the initial/startup capacity of the ring buffer.
+#### Sets the initial/startup (required) capacity of the ring buffer.
 
 ```csharp
 public IRingBuffer Capacity(int value)

--- a/src/docs/assemblies/RingBufferPlus/IRingBufferScaleCapacity-1.md
+++ b/src/docs/assemblies/RingBufferPlus/IRingBufferScaleCapacity-1.md
@@ -19,7 +19,7 @@ public interface IRingBufferScaleCapacity<T> : IRingBufferBuild<T>
 | name | description |
 | --- | --- |
 | [AutoScaleAcquireFault](IRingBufferScaleCapacity-1/AutoScaleAcquireFault.md)(…) | Sets the condition to autoscale (scale up) capacity when an acquire fault occurs. The Manually change scale will always return false if autoscale is enabled. |
-| [LockAcquireWhenAutoScale](IRingBufferScaleCapacity-1/LockAcquireWhenAutoScale.md)(…) | Sets acquisition lock when running auto scale. |
+| [LockWhenScaling](IRingBufferScaleCapacity-1/LockWhenScaling.md)(…) | Sets acquisition/Switch lock when running scaleUp/ScaleDown. |
 | [MaxCapacity](IRingBufferScaleCapacity-1/MaxCapacity.md)(…) | Sets the maximum capacity. |
 | [MinCapacity](IRingBufferScaleCapacity-1/MinCapacity.md)(…) | Sets the minimum capacity. |
 

--- a/src/docs/assemblies/RingBufferPlus/IRingBufferScaleCapacity-1/LockWhenScaling.md
+++ b/src/docs/assemblies/RingBufferPlus/IRingBufferScaleCapacity-1/LockWhenScaling.md
@@ -1,13 +1,13 @@
 ![RingBufferPlus Logo](https://raw.githubusercontent.com/FRACerqueira/RingBufferPlus/refs/heads/main/icon.png)
 
-### IRingBufferScaleCapacity&lt;T&gt;.LockAcquireWhenAutoScale method
+### IRingBufferScaleCapacity&lt;T&gt;.LockWhenScaling method
 </br>
 
 
-#### Sets acquisition lock when running auto scale.
+#### Sets acquisition/Switch lock when running scaleUp/ScaleDown.
 
 ```csharp
-public IRingBufferScaleCapacity LockAcquireWhenAutoScale(bool value = true)
+public IRingBufferScaleCapacity LockWhenScaling(bool value = true)
 ```
 
 | parameter | description |


### PR DESCRIPTION
- Renamed for readability syntax : LockAcquireWhenAutoScale -> LockWhenScaling
- Updated docs and readme and description package
- Improvements to example with rabbitMQ