### PR TITLE
Fix csproj path, refactor exceptions, and update tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
       # to the one TFM whose runtime is actually present (the test project multi-targets
       # net8.0/net9.0/net10.0 - see ADR002's revision note on CI test execution).
       - name: Test
+        if: matrix.os != 'macos-latest'
         run: >
           dotnet test
           --framework net10.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,11 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build (Release)
-        run: dotnet build src/RingBufferPlus.csproj --configuration Release -p:Version=${{ steps.version.outputs.VERSION }}
+        run: dotnet build src/RingBufferPlus/RingBufferPlus.csproj --configuration Release -p:Version=${{ steps.version.outputs.VERSION }}
 
       - name: Pack tool
         run: >
-          dotnet pack src/RingBufferPlus.csproj
+          dotnet pack src/RingBufferPlus/RingBufferPlus.csproj
           --no-build
           --configuration Release
           -p:Version=${{ steps.version.outputs.VERSION }}

--- a/samples/RingBufferPlusBasicSample/Program.cs
+++ b/samples/RingBufferPlusBasicSample/Program.cs
@@ -44,11 +44,9 @@ namespace RingBufferPlusBasicSample
             Console.ReadKey();
             await using (var buffer1 = await rb.AcquireAsync(tokenapplifetime))
             {
-                await using (var buffer2 = await rb.AcquireAsync(tokenapplifetime))
-                {
-                    Console.WriteLine($"Buffer is ok({buffer1.Successful}:{buffer1.ElapsedTime}) value: {buffer1.Current}");
-                    Console.WriteLine($"Buffer is ok({buffer2.Successful}:{buffer2.ElapsedTime}) value: {buffer2.Current}");
-                }
+                await using var buffer2 = await rb.AcquireAsync(tokenapplifetime);
+                Console.WriteLine($"Buffer is ok({buffer1.Successful}:{buffer1.ElapsedTime}) value: {buffer1.Current}");
+                Console.WriteLine($"Buffer is ok({buffer2.Successful}:{buffer2.ElapsedTime}) value: {buffer2.Current}");
             }
 
             Console.WriteLine("Press any key to Acquire buffer and invalidate item buffer");

--- a/src/RingBufferPlus.Tests/RingBufferBuilderTests.cs
+++ b/src/RingBufferPlus.Tests/RingBufferBuilderTests.cs
@@ -279,7 +279,7 @@ namespace RingBufferPlus.Tests
         {
             var builder = CreateBuilder().Factory(_ => Task.FromResult(0)).ElasticCapacity(5, 2, 10, 0, TimeSpan.FromSeconds(5));
 
-            Assert.Throws<IndexOutOfRangeException>(() => builder.Build());
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
         }
 
         [Fact]
@@ -287,7 +287,7 @@ namespace RingBufferPlus.Tests
         {
             var builder = CreateBuilder().Factory(_ => Task.FromResult(0)).ElasticCapacity(5, 2, 10, 10, TimeSpan.FromMilliseconds(500));
 
-            Assert.Throws<IndexOutOfRangeException>(() => builder.Build());
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
         }
     }
 }

--- a/src/RingBufferPlus/Core/RingBufferBuilder.cs
+++ b/src/RingBufferPlus/Core/RingBufferBuilder.cs
@@ -267,13 +267,13 @@ namespace RingBufferPlus.Core
                 }
                 if (_sampleUnit < 1)
                 {
-                    var err = new IndexOutOfRangeException("numberSamples in command ElasticCapacity must be greater or equal 1");
+                    var err = new InvalidOperationException("numberSamples in command ElasticCapacity must be greater or equal 1");
                     LogError(err);
                     throw err;
                 }
                 if (_samplebasetime.TotalMilliseconds / _sampleUnit < 100)
                 {
-                    var err = new IndexOutOfRangeException("baseTimer / numberSamples in command ElasticCapacity must be greater or equal 100ms");
+                    var err = new InvalidOperationException("baseTimer / numberSamples in command ElasticCapacity must be greater or equal 100ms");
                     LogError(err);
                     throw err;
                 }
@@ -321,7 +321,7 @@ namespace RingBufferPlus.Core
             }
         }
 
-        private static readonly Action<ILogger, string, string, Exception?> logMessageForDbg = LoggerMessage.Define<string, string>(LogLevel.Debug, 0, "RingBufferBuilder({source}) : {message}");
-        private static readonly Action<ILogger, string, string, Exception?> logMessageForErr = LoggerMessage.Define<string, string>(LogLevel.Error, 0, "RingBufferBuilder({source}) : {message}");
+        private static readonly Action<ILogger, string, string, Exception?> logMessageForDbg = LoggerMessage.Define<string, string>(LogLevel.Debug, 0, "RingBufferBuilder({Source}) : {Message}");
+        private static readonly Action<ILogger, string, string, Exception?> logMessageForErr = LoggerMessage.Define<string, string>(LogLevel.Error, 0, "RingBufferBuilder({Source}) : {Message}");
     }
 }

--- a/src/RingBufferPlus/Core/RingBufferManager.cs
+++ b/src/RingBufferPlus/Core/RingBufferManager.cs
@@ -129,6 +129,7 @@ namespace RingBufferPlus.Core
 
         #endregion
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2016:Forward the 'CancellationToken' parameter to methods", Justification = "ByDesign")]
         public RingBufferManager(CancellationToken lifetimecancellation)
         {
             _lifetime = CancellationTokenSource.CreateLinkedTokenSource(lifetimecancellation);
@@ -747,9 +748,9 @@ namespace RingBufferPlus.Core
             }
         }
 
-        private static readonly Action<ILogger, string, string, Exception?> logMessageForDbg = LoggerMessage.Define<string, string>(LogLevel.Debug, 0, "RingBufferManager({source}) : {message}");
-        private static readonly Action<ILogger, string, string, Exception?> logMessageForErr = LoggerMessage.Define<string, string>(LogLevel.Error, 0, "RingBufferManager({source}) : {message}");
-        private static readonly Action<ILogger, string, string, Exception?> logMessageFoWrn = LoggerMessage.Define<string, string>(LogLevel.Warning, 0, "RingBufferManager({source}) : {message}");
+        private static readonly Action<ILogger, string, string, Exception?> logMessageForDbg = LoggerMessage.Define<string, string>(LogLevel.Debug, 0, "RingBufferManager({Source}) : {Message}");
+        private static readonly Action<ILogger, string, string, Exception?> logMessageForErr = LoggerMessage.Define<string, string>(LogLevel.Error, 0, "RingBufferManager({Source}) : {Message}");
+        private static readonly Action<ILogger, string, string, Exception?> logMessageFoWrn = LoggerMessage.Define<string, string>(LogLevel.Warning, 0, "RingBufferManager({Source}) : {Message}");
 
         #endregion
 

--- a/src/RingBufferPlus/RingBufferExtension.cs
+++ b/src/RingBufferPlus/RingBufferExtension.cs
@@ -20,6 +20,7 @@ namespace RingBufferPlus
         /// </summary>
         /// <param name="buffername">The unique name to RingBuffer.</param>
         /// <returns><see cref="IRingBufferBuilder{T}"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "ByDesign")]
         public static IRingBufferBuilder<T> New(string buffername)
         {
             if (buffername is null)
@@ -34,6 +35,7 @@ namespace RingBufferPlus
         /// <param name="buffername">The unique name to RingBuffer.</param>
         /// <param name="loggerFactory">The logger factory to create a logger.</param>
         /// <returns><see cref="IRingBufferBuilder{T}"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "ByDesign")]
         public static IRingBufferBuilder<T> New(string? buffername, ILoggerFactory loggerFactory)
         {
             if (buffername is null)

--- a/src/RingBufferPlus/RingBufferPlus.csproj
+++ b/src/RingBufferPlus/RingBufferPlus.csproj
@@ -4,7 +4,8 @@
 		<TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<LangVersion>latestmajor</LangVersion>
+		<LangVersion>latest</LangVersion>
+		<AnalysisLevel>latest-recommended</AnalysisLevel>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
This pull request includes several improvements and fixes across the codebase, focusing on exception handling, code quality, logging consistency, and CI/CD workflow correctness. The most important changes are summarized below.

### Exception Handling and Validation

* Changed thrown exceptions in `RingBufferBuilder` validation from `IndexOutOfRangeException` to `InvalidOperationException` for invalid configuration scenarios, and updated corresponding unit tests to expect the new exception type. [[1]](diffhunk://#diff-327c7b32561fb4eb3be644a94a7f0f21eabe9eba3d8c5a452ac13bea0589a3bdL270-R276) [[2]](diffhunk://#diff-28437007843690623bc9e8a50d318663a0527c301f4a042304d7b0807b89caf4L282-R290)

### Code Quality and Analyzer Compliance

* Added `SuppressMessage` attributes to suppress specific code analysis warnings in `RingBufferManager` and `RingBufferExtension`, justifying design decisions. [[1]](diffhunk://#diff-b0074c41f0dbecee550229c93e6081aa78dd7d720161bb65f22a00c2af1418a4R132) [[2]](diffhunk://#diff-a29a08936dec847cb5a5cbaf3b37898015d36a8a1faeb500596dac71d0e0d01aR23) [[3]](diffhunk://#diff-a29a08936dec847cb5a5cbaf3b37898015d36a8a1faeb500596dac71d0e0d01aR38)
* Updated `LangVersion` to `latest` and added `AnalysisLevel` set to `latest-recommended` in `RingBufferPlus.csproj` for improved code analysis and language feature support.

### Logging Consistency

* Standardized logging message templates in `RingBufferBuilder` and `RingBufferManager` to use `{Source}` and `{Message}` placeholders for better log clarity. [[1]](diffhunk://#diff-327c7b32561fb4eb3be644a94a7f0f21eabe9eba3d8c5a452ac13bea0589a3bdL324-R325) [[2]](diffhunk://#diff-b0074c41f0dbecee550229c93e6081aa78dd7d720161bb65f22a00c2af1418a4L750-R753)

### CI/CD Workflow and Build Fixes

* Corrected project paths in the `publish.yml` workflow to build and pack the correct project file (`src/RingBufferPlus/RingBufferPlus.csproj`).
* Updated the `build.yml` workflow to skip tests on macOS runners, ensuring compatibility with available .NET runtimes.

### Code Cleanup

* Simplified a nested `await using` block in the sample program for improved readability.